### PR TITLE
The 'formatter' parameter is not valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 
 	module.exports = {
 		root: true,
-		formatter: "unix",
 		plugins: [
 			"ftgp",
 			"jasmine"


### PR DESCRIPTION
eslint 4 is stricter than its predecessors regarding unknown properties:
https://eslint.org/docs/user-guide/migrating-to-4.0.0#-unrecognized-properties-in-config-files-now-cause-a-fatal-error